### PR TITLE
Consolidate threads/eventloops; update gRPC version, fix retry timing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,8 @@
    </distributionManagement>
 
    <properties>
-      <grpc-version>1.11.0</grpc-version>
+      <grpc-version>1.12.0</grpc-version>
+      <netty-version>4.1.22.Final</netty-version>
       <netty-tcnative-version>2.0.7.Final</netty-tcnative-version>
       <protoc-version>3.5.1-1</protoc-version>
       <gson-version>2.7</gson-version>
@@ -67,6 +68,12 @@
    </properties>
 
    <dependencies>
+       <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-transport-native-epoll</artifactId>
+         <version>${netty-version}</version>
+         <classifier>${os.detected.name}-${os.detected.arch}</classifier>
+      </dependency>
       <dependency>
          <groupId>io.netty</groupId>
          <artifactId>netty-tcnative-boringssl-static</artifactId>
@@ -133,7 +140,7 @@
          <extension>
             <groupId>kr.motd.maven</groupId>
             <artifactId>os-maven-plugin</artifactId>
-            <version>1.4.1.Final</version>
+            <version>1.5.0.Final</version>
          </extension>
       </extensions>
       <plugins>

--- a/src/main/java/com/ibm/etcd/client/utils/PersistentLeaseKey.java
+++ b/src/main/java/com/ibm/etcd/client/utils/PersistentLeaseKey.java
@@ -27,8 +27,8 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.google.protobuf.ByteString;
 import com.ibm.etcd.client.EtcdClient;
 import com.ibm.etcd.client.FutureListener;
+import com.ibm.etcd.client.GrpcClient;
 import com.ibm.etcd.client.ListenerObserver;
-import com.ibm.etcd.client.SerializingExecutor;
 import com.ibm.etcd.client.kv.KvClient;
 import com.ibm.etcd.client.lease.PersistentLease;
 import com.ibm.etcd.client.lease.PersistentLease.LeaseState;
@@ -119,7 +119,7 @@ public class PersistentLeaseKey extends AbstractFuture<ByteString> implements Au
         if(executor != null) throw new IllegalStateException("already started");
         if(closeFuture != null) throw new IllegalStateException("closed");
         //TODO TBD or have lease expose its response executor
-        executor = new SerializingExecutor(client.getExecutor());
+        executor = GrpcClient.serialized(client.getExecutor(), 0);
         if(lease == null) lease = client.getSessionLease();
         lease.addStateObserver(stateObserver, true);
     }

--- a/src/main/java/com/ibm/etcd/client/utils/RangeCache.java
+++ b/src/main/java/com/ibm/etcd/client/utils/RangeCache.java
@@ -50,8 +50,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
 import com.ibm.etcd.client.EtcdClient;
+import com.ibm.etcd.client.GrpcClient;
 import com.ibm.etcd.client.KeyUtils;
-import com.ibm.etcd.client.SerializingExecutor;
 import com.ibm.etcd.client.kv.KvClient;
 import com.ibm.etcd.client.kv.WatchUpdate;
 import com.ibm.etcd.client.kv.KvClient.Watch;
@@ -99,7 +99,7 @@ public class RangeCache implements AutoCloseable, Iterable<KeyValue> {
     
     private final ByteString fromKey, toKey;
     
-    private final EtcdClient client;
+    private final transient EtcdClient client;
     private final KvClient kvClient;
     private /*final*/ Watch watch;
     
@@ -137,7 +137,7 @@ public class RangeCache implements AutoCloseable, Iterable<KeyValue> {
             int diff = Long.compare(kv1.getModRevision(), kv2.getModRevision());
             return diff != 0 ? diff : KeyUtils.compareByteStrings(kv1.getKey(), kv2.getKey());
         });
-        this.listenerExecutor = new SerializingExecutor(client.getExecutor());
+        this.listenerExecutor = GrpcClient.serialized(client.getExecutor(), 0);
     }
     
     /**

--- a/src/test/java/com/ibm/etcd/client/WatchTest.java
+++ b/src/test/java/com/ibm/etcd/client/WatchTest.java
@@ -161,7 +161,7 @@ public class WatchTest {
             proxy.start();
 
             // watch should be unaffected - next event seen should be the missed one
-            wu = (WatchUpdate)watchEvents.poll(3000L, TimeUnit.MILLISECONDS);
+            wu = (WatchUpdate)watchEvents.poll(4000L, TimeUnit.MILLISECONDS);
             assertEquals(bs("/watchtest/e"), wu.getEvents().get(0).getKv().getKey());
 
             watch.close();


### PR DESCRIPTION
This PR streamlines etcd-java's use of threads, sharing the gRPC/netty `EventLoopGroup`s for other "internal" purposes. Other changes include:
- Reducing the default size of the `EventLoopGroup`s used - netty defaults to 2x number of cores which is typically much larger than needed. The size can be overriden via the `withThreadCount()` client builder option
- Use epoll transport if available
- Fix/improve retry logic - the first "delayed" retry was previously incorrectly scheduled to happen immediately (having already just been immediately retried). Also rate-limit immediate retries to reduce requests attempted during connection issues
- Send all rpc messages via the internal `EventLoopGroup`, which improves behaviour of netty's thread-local pooled buffer caches. This might have a small performance trade-off and can be disabled via the new `sendViaEventLoop()` client builder option
- Support providing a custom default executor in the client builder to use for async user call-backs (defaults to `ForkJoinPool.commonPool()` otherwise)
- Update grpc-java dependency to latest version 1.12.0
- Add/tweak some log statements