### PR TITLE
Improvements to Lease functionality/resiliency

### DIFF
--- a/src/main/java/com/ibm/etcd/client/FluentRequest.java
+++ b/src/main/java/com/ibm/etcd/client/FluentRequest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2017, 2018 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ibm.etcd.client;
+
+import java.util.concurrent.Executor;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.protobuf.GeneratedMessageV3.Builder;
+import com.ibm.etcd.client.kv.KvClient.RetryStrategy;
+
+import io.grpc.Deadline;
+import io.grpc.MethodDescriptor;
+
+/**
+ * Internal superinterface used for fluent API requests
+ */
+public interface FluentRequest<FR extends FluentRequest<FR,ReqT,RespT>,ReqT,RespT> {
+    ListenableFuture<RespT> async();
+    ListenableFuture<RespT> async(Executor executor);
+    RespT sync();
+    /**
+     * timeout is <b>per attempt</b>
+     */
+    FR timeout(long millisecs);
+    /**
+     * deadline is absolute for entire request
+     */
+    FR deadline(Deadline deadline);
+    FR backoffRetry();
+    FR backoffRetry(Condition precondition);
+    ReqT asRequest();
+    
+    
+    @SuppressWarnings("unchecked")
+    abstract class AbstractFluentRequest<FR extends FluentRequest<FR,ReqT,RespT>,ReqT,RespT,BldT
+        extends Builder<BldT>> implements FluentRequest<FR,ReqT,RespT> {
+        
+        protected final GrpcClient client;
+        protected final BldT builder;
+        protected RetryStrategy retryStrategy = RetryStrategy.BASIC;
+        protected Condition precondition;
+        protected long timeoutMs;
+        protected Deadline deadline;
+        
+        protected AbstractFluentRequest(GrpcClient client, BldT builder) {
+            this.client = client;
+            this.builder = builder;
+        }
+        
+        protected abstract MethodDescriptor<ReqT,RespT> getMethod();
+        protected abstract boolean idempotent();
+        
+        @Override
+        public FR timeout(long millisecs) {
+            this.timeoutMs = millisecs;
+            return (FR) this;
+        }
+        @Override
+        public FR deadline(Deadline deadline) {
+            this.deadline = deadline;
+            return (FR) this;
+        }
+        @Override
+        final public FR backoffRetry() {
+            this.retryStrategy = RetryStrategy.BACKOFF;
+            return (FR) this;
+        }
+        @Override
+        final public FR backoffRetry(Condition precondition) {
+            this.retryStrategy = RetryStrategy.BACKOFF;
+            this.precondition = precondition;
+            return (FR) this;
+        }
+        @Override
+        final public ReqT asRequest() {
+            return (ReqT) builder.build();
+        }
+        @Override
+        public ListenableFuture<RespT> async(Executor executor) {
+            return client.call(getMethod(), precondition, (ReqT)builder.build(),
+                    executor, GrpcClient.retryDecision(idempotent()), 
+                    retryStrategy == RetryStrategy.BACKOFF, deadline, timeoutMs);
+        }
+        @Override
+        final public ListenableFuture<RespT> async() {
+            return async(null);
+        }
+        @Override
+        final public RespT sync() {
+            return GrpcClient.waitFor(this::async);
+        }
+    }
+}

--- a/src/main/java/com/ibm/etcd/client/kv/KvClient.java
+++ b/src/main/java/com/ibm/etcd/client/kv/KvClient.java
@@ -22,8 +22,6 @@ import java.util.concurrent.Executor;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
-import com.ibm.etcd.client.Condition;
-import com.ibm.etcd.client.watch.RevisionCompactedException;
 import com.ibm.etcd.api.DeleteRangeRequest;
 import com.ibm.etcd.api.DeleteRangeRequestOrBuilder;
 import com.ibm.etcd.api.DeleteRangeResponse;
@@ -40,6 +38,8 @@ import com.ibm.etcd.api.TxnRequestOrBuilder;
 import com.ibm.etcd.api.TxnResponse;
 import com.ibm.etcd.api.WatchCreateRequest;
 import com.ibm.etcd.api.WatchCreateRequest.FilterType;
+import com.ibm.etcd.client.Condition;
+import com.ibm.etcd.client.watch.RevisionCompactedException;
 
 import io.grpc.Deadline;
 import io.grpc.stub.StreamObserver;
@@ -54,21 +54,15 @@ public interface KvClient {
      */
     public static final ByteString ALL_KEYS = ByteString.copyFromUtf8("ALL_KEYS");
     
-    interface FluentRequest<FR extends FluentRequest<FR,ReqT,RespT>,ReqT,RespT> {
-        ListenableFuture<RespT> async();
-        ListenableFuture<RespT> async(Executor executor);
-        RespT sync();
-        /**
-         * timeout is <b>per attempt</b>
-         */
-        FR timeout(long millisecs);
-        /**
-         * deadline is absolute for entire request
-         */
-        FR deadline(Deadline deadline);
-        FR backoffRetry();
-        FR backoffRetry(Condition precondition);
-        ReqT asRequest();
+    /**
+     * Needed for backwards binary compatibility
+     */
+    interface FluentRequest<FR extends FluentRequest<FR,ReqT,RespT>,ReqT,RespT>
+        extends com.ibm.etcd.client.FluentRequest<FR, ReqT, RespT> {
+        @Override FR timeout(long millisecs);
+        @Override FR deadline(Deadline deadline);
+        @Override FR backoffRetry();
+        @Override FR backoffRetry(Condition precondition);
     }
     
     interface FluentRangeRequest extends FluentRequest<FluentRangeRequest,RangeRequest,RangeResponse> {

--- a/src/main/java/com/ibm/etcd/client/lease/LeaseClient.java
+++ b/src/main/java/com/ibm/etcd/client/lease/LeaseClient.java
@@ -18,7 +18,9 @@ package com.ibm.etcd.client.lease;
 import java.util.concurrent.Executor;
 
 import com.google.common.util.concurrent.ListenableFuture;
+import com.ibm.etcd.client.FluentRequest;
 import com.ibm.etcd.client.lease.PersistentLease.LeaseState;
+import com.ibm.etcd.api.LeaseGrantRequest;
 import com.ibm.etcd.api.LeaseGrantResponse;
 import com.ibm.etcd.api.LeaseKeepAliveResponse;
 import com.ibm.etcd.api.LeaseLeasesResponse;
@@ -31,6 +33,10 @@ import io.grpc.stub.StreamObserver;
  * Lease operations
  */
 public interface LeaseClient {
+    
+    interface FluentGrantRequest extends FluentRequest<FluentGrantRequest,LeaseGrantRequest,LeaseGrantResponse> {
+        FluentGrantRequest leaseId(long leaseId);
+    }
     
     interface FluentMaintainRequest {
         FluentMaintainRequest leaseId(long leaseId);
@@ -61,10 +67,24 @@ public interface LeaseClient {
     
     /**
      * 
+     * @param ttlSecs
+     * @return TODO
+     */
+    FluentGrantRequest grant(long ttlSecs);
+    
+    /**
+     * 
      * @param leaseId
      * @return future for {@link LeaseRevokeResponse}
      */
     ListenableFuture<LeaseRevokeResponse> revoke(long leaseId);
+    
+    /**
+     * 
+     * @param leaseId
+     * @return future for {@link LeaseRevokeResponse}
+     */
+    ListenableFuture<LeaseRevokeResponse> revoke(long leaseId, boolean ensureWithRetries);
     
     /**
      * 


### PR DESCRIPTION
- Support `LeaseClient.keepAliveOnce()`
- Add "robust" revoke option for one-time leases which will retry in the background
- Richer one-time grant requests (with timeout/retry options, etc)
- Improve `PersistentLease` internal create/revoke failure retry behaviour
- Streamline internal executor use