### PR TITLE
Add support for server-side locks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Robust etcd3 java client
 
 ## Usage
 
-Create the client. Methods are grouped into separate `KvClient` and `LeaseClient` interfaces.
+Create the client. Methods are grouped into separate `KvClient`, `LeaseClient` and `LockClient` interfaces.
 
 
 ```java
@@ -117,6 +117,14 @@ Obtain a shared persistent lease whose life is tied to the client, and subscribe
 PersistentLease sessionLease = client.getSessionLease();
 sessionLease.addStateObserver(myObserver);
 
+```
+
+Establish a named lock using the client's session lease, then release it
+
+```java
+ByteString lockKey = lockClient.lock(name).sync().getKey();
+// ...
+lockClient.unlock(lockKey).sync();
 ```
 
 Instantiate a client using a cluster configuration JSON file

--- a/src/main/java/com/ibm/etcd/client/EtcdClient.java
+++ b/src/main/java/com/ibm/etcd/client/EtcdClient.java
@@ -47,7 +47,9 @@ import com.ibm.etcd.api.AuthGrpc;
 import com.ibm.etcd.api.AuthenticateRequest;
 import com.ibm.etcd.api.AuthenticateResponse;
 import com.ibm.etcd.client.kv.EtcdKvClient;
+import com.ibm.etcd.client.kv.EtcdLockClient;
 import com.ibm.etcd.client.kv.KvClient;
+import com.ibm.etcd.client.kv.LockClient;
 import com.ibm.etcd.client.lease.EtcdLeaseClient;
 import com.ibm.etcd.client.lease.LeaseClient;
 import com.ibm.etcd.client.lease.PersistentLease;
@@ -103,6 +105,7 @@ public class EtcdClient implements KvStoreClient {
     
     private final EtcdKvClient kvClient;
     private volatile LeaseClient leaseClient; // lazy-instantiated
+    private volatile LockClient lockClient; // lazy-instantiated
     private volatile PersistentLease sessionLease; // lazy-instantiated
     
     public static class Builder {
@@ -418,6 +421,17 @@ public class EtcdClient implements KvStoreClient {
         if(lc == null) synchronized(this) {
             if((lc=leaseClient) == null) {
                 leaseClient = lc = new EtcdLeaseClient(grpc);
+            }
+        }
+        return lc;
+    }
+    
+    @Override
+    public LockClient getLockClient() {
+        LockClient lc = lockClient;
+        if(lc == null) synchronized(this) {
+            if((lc=lockClient) == null) {
+                lockClient = lc = new EtcdLockClient(grpc, this);
             }
         }
         return lc;

--- a/src/main/java/com/ibm/etcd/client/FluentRequest.java
+++ b/src/main/java/com/ibm/etcd/client/FluentRequest.java
@@ -95,11 +95,11 @@ public interface FluentRequest<FR extends FluentRequest<FR,ReqT,RespT>,ReqT,Resp
                     retryStrategy == RetryStrategy.BACKOFF, deadline, timeoutMs);
         }
         @Override
-        final public ListenableFuture<RespT> async() {
+        public final ListenableFuture<RespT> async() {
             return async(null);
         }
         @Override
-        final public RespT sync() {
+        public final RespT sync() {
             return GrpcClient.waitFor(this::async);
         }
     }

--- a/src/main/java/com/ibm/etcd/client/KvStoreClient.java
+++ b/src/main/java/com/ibm/etcd/client/KvStoreClient.java
@@ -18,6 +18,7 @@ package com.ibm.etcd.client;
 import java.io.Closeable;
 
 import com.ibm.etcd.client.kv.KvClient;
+import com.ibm.etcd.client.kv.LockClient;
 import com.ibm.etcd.client.lease.LeaseClient;
 import com.ibm.etcd.client.lease.PersistentLease;
 
@@ -26,6 +27,8 @@ public interface KvStoreClient extends Closeable {
     public KvClient getKvClient();
     
     public LeaseClient getLeaseClient();
+    
+    public LockClient getLockClient();
     
     /**
      * Returns a singular {@link PersistentLease} bound

--- a/src/main/java/com/ibm/etcd/client/kv/EtcdKvClient.java
+++ b/src/main/java/com/ibm/etcd/client/kv/EtcdKvClient.java
@@ -57,7 +57,7 @@ import io.grpc.Deadline;
 import io.grpc.MethodDescriptor;
 import io.grpc.stub.StreamObserver;
 
-public class EtcdKvClient implements KvClient {
+public final class EtcdKvClient implements KvClient {
     
     // avoid volatile read on every invocation
     private static final MethodDescriptor<RangeRequest,RangeResponse> METHOD_RANGE =
@@ -145,7 +145,7 @@ public class EtcdKvClient implements KvClient {
         return new EtcdDeleteRequest(key);
     }
 
-    class EtcdRangeRequest extends AbstractFluentRequest<FluentRangeRequest,RangeRequest,
+    final class EtcdRangeRequest extends AbstractFluentRequest<FluentRangeRequest,RangeRequest,
         RangeResponse,RangeRequest.Builder> implements FluentRangeRequest {
         
         EtcdRangeRequest(ByteString key) {
@@ -233,7 +233,7 @@ public class EtcdKvClient implements KvClient {
         }
     }
     
-    class EtcdDeleteRequest extends AbstractFluentRequest<FluentDeleteRequest,DeleteRangeRequest,
+    final class EtcdDeleteRequest extends AbstractFluentRequest<FluentDeleteRequest,DeleteRangeRequest,
         DeleteRangeResponse,DeleteRangeRequest.Builder> implements FluentDeleteRequest {
         
         EtcdDeleteRequest(ByteString key) {
@@ -271,7 +271,7 @@ public class EtcdKvClient implements KvClient {
         }
     }
     
-    class EtcdPutRequest extends AbstractFluentRequest<FluentPutRequest,PutRequest,
+    final class EtcdPutRequest extends AbstractFluentRequest<FluentPutRequest,PutRequest,
         PutResponse,PutRequest.Builder> implements FluentPutRequest {
         EtcdPutRequest() {
             super(EtcdKvClient.this.client, PutRequest.newBuilder());
@@ -305,7 +305,7 @@ public class EtcdKvClient implements KvClient {
         }
     }
     
-    class EtcdTxnRequest extends AbstractFluentRequest<FluentTxnRequest,TxnRequest,
+    final class EtcdTxnRequest extends AbstractFluentRequest<FluentTxnRequest,TxnRequest,
         TxnResponse,TxnRequest.Builder> implements FluentTxnRequest {
         
         final Compare.Builder cmpBld = Compare.newBuilder(); //reused
@@ -359,7 +359,7 @@ public class EtcdKvClient implements KvClient {
                     : (TXN_OPS = new EtcdTxnOps());
         }
         
-        class EtcdCmpTarget implements FluentCmpTarget {
+        final class EtcdCmpTarget implements FluentCmpTarget {
             @Override
             public FluentCmpTarget allInRange(ByteString rangeEnd) {
                 cmpBld.setRangeEnd(rangeEnd);
@@ -406,7 +406,7 @@ public class EtcdKvClient implements KvClient {
             }
         }
         
-        class EtcdTxnOps implements FluentTxnSuccOps {
+        final class EtcdTxnOps implements FluentTxnSuccOps {
             private final RequestOp.Builder opBld = RequestOp.newBuilder();
             private boolean succ = true;
             
@@ -509,7 +509,7 @@ public class EtcdKvClient implements KvClient {
         }
     }
     
-    class EtcdWatchRequest implements FluentWatchRequest {
+    final class EtcdWatchRequest implements FluentWatchRequest {
         private final WatchCreateRequest.Builder builder = WatchCreateRequest.newBuilder();
         
         private Executor executor;

--- a/src/main/java/com/ibm/etcd/client/kv/EtcdLockClient.java
+++ b/src/main/java/com/ibm/etcd/client/kv/EtcdLockClient.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2017, 2018 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ibm.etcd.client.kv;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeoutException;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.protobuf.ByteString;
+import com.ibm.etcd.api.LockGrpc;
+import com.ibm.etcd.api.LockRequest;
+import com.ibm.etcd.api.LockResponse;
+import com.ibm.etcd.api.UnlockRequest;
+import com.ibm.etcd.api.UnlockResponse;
+import com.ibm.etcd.client.EtcdClient;
+import com.ibm.etcd.client.FluentRequest.AbstractFluentRequest;
+import com.ibm.etcd.client.GrpcClient;
+import com.ibm.etcd.client.lease.PersistentLease;
+
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+
+public final class EtcdLockClient implements LockClient {
+    
+    // avoid volatile read on every invocation
+    private static final MethodDescriptor<LockRequest,LockResponse> METHOD_LOCK =
+            LockGrpc.getLockMethod();
+    private static final MethodDescriptor<UnlockRequest,UnlockResponse> METHOD_UNLOCK =
+            LockGrpc.getUnlockMethod();
+
+    protected final EtcdClient etcdClient;
+    protected final GrpcClient grpcClient;
+    
+    public EtcdLockClient(GrpcClient grpcClient, EtcdClient etcdClient) {
+        this.grpcClient = grpcClient;
+        this.etcdClient = etcdClient;
+    }
+    
+    final class EtcdLockRequest extends AbstractFluentRequest<FluentLockRequest,
+        LockRequest,LockResponse,LockRequest.Builder> implements FluentLockRequest {
+        PersistentLease lease;
+        
+        EtcdLockRequest(ByteString name) {
+            super(grpcClient, LockRequest.newBuilder().setName(name));
+        }
+        @Override
+        protected MethodDescriptor<LockRequest, LockResponse> getMethod() {
+            return METHOD_LOCK;
+        }
+        @Override
+        protected boolean idempotent() {
+            return true;
+        }
+        @Override
+        public FluentLockRequest withLease(long leaseId) {
+            builder.setLease(leaseId);
+            lease = null;
+            return this;
+        }
+        @Override
+        public FluentLockRequest withLease(PersistentLease lease) {
+            this.lease = lease;
+            return this;
+        }
+
+        @Override
+        public final ListenableFuture<LockResponse> async(Executor executor) {
+            if(lease == null) {
+                if(builder.getLease() != 0L) return super.async(executor);
+                else lease = etcdClient.getSessionLease();
+            }
+            long plId = lease.getLeaseId();
+            if(plId != 0L) {
+                builder.setLease(plId);
+                return super.async(executor);
+            }
+            ListenableFuture<Long> fut;
+            if(deadline == null) fut = lease;
+            else {
+                long remainingNanos = deadline.timeRemaining(NANOSECONDS);
+                fut = Futures.catching(Futures.withTimeout(lease,
+                        remainingNanos, NANOSECONDS, grpcClient.getInternalExecutor()),
+                        TimeoutException.class, te -> {
+                            throw Status.DEADLINE_EXCEEDED.withCause(te)
+                            .withDescription(String.format("deadline exceeded after %dns",
+                                    remainingNanos)).asRuntimeException();
+                        }, MoreExecutors.directExecutor());
+            }
+            return Futures.transformAsync(fut, id -> {
+                builder.setLease(id);
+                return super.async(executor);
+            }, executor);
+        }
+    }
+    
+    @Override
+    public FluentLockRequest lock(ByteString name) {
+        return new EtcdLockRequest(name);
+    }
+    
+    final class EtcdUnlockRequest extends AbstractFluentRequest<FluentUnlockRequest,
+        UnlockRequest,UnlockResponse,UnlockRequest.Builder> implements FluentUnlockRequest {
+
+        EtcdUnlockRequest(ByteString key) {
+            super(grpcClient, UnlockRequest.newBuilder().setKey(key));
+        }
+        @Override
+        protected MethodDescriptor<UnlockRequest, UnlockResponse> getMethod() {
+            return METHOD_UNLOCK;
+        }
+        @Override
+        protected boolean idempotent() {
+            return true;
+        }
+    }
+
+    @Override
+    public FluentUnlockRequest unlock(ByteString key) {
+        return new EtcdUnlockRequest(key);
+    }
+}

--- a/src/main/java/com/ibm/etcd/client/kv/LockClient.java
+++ b/src/main/java/com/ibm/etcd/client/kv/LockClient.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017, 2018 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ibm.etcd.client.kv;
+
+import com.google.protobuf.ByteString;
+import com.ibm.etcd.api.LockRequest;
+import com.ibm.etcd.api.LockResponse;
+import com.ibm.etcd.api.UnlockRequest;
+import com.ibm.etcd.api.UnlockResponse;
+import com.ibm.etcd.client.FluentRequest;
+import com.ibm.etcd.client.lease.PersistentLease;
+
+/**
+ * Lock operations
+ */
+public interface LockClient {
+
+    interface FluentLockRequest extends FluentRequest<FluentLockRequest,LockRequest,LockResponse> {
+        FluentLockRequest withLease(long leaseId);
+        FluentLockRequest withLease(PersistentLease lease);
+    }
+    
+    interface FluentUnlockRequest extends FluentRequest<FluentUnlockRequest,UnlockRequest,UnlockResponse> {}
+    
+    /**
+     * Acquire a lock with the given name. Unless one of the {@code withLease()}
+     * methods is used, the lock will be tied to this client's session lease.
+     * <p>
+     * The response contains a key whose existence is tied to the caller's ownership
+     * of the lock. This key can be used in conjunction with transactions to safely
+     * ensure updates to etcd only occur while holding lock ownership. The lock is held
+     * until Unlock is called on the key or the lease associated with the owner expires.
+     * 
+     * @param name unique name identifying the lock
+     */
+    FluentLockRequest lock(ByteString name);
+   
+    /**
+     * Release the lock with the given key.
+     * 
+     * @param key unique key returned in the {@link LockResponse}
+     *   from the {@link #lock(ByteString)} method.
+     */
+    FluentUnlockRequest unlock(ByteString key);
+}

--- a/src/main/java/com/ibm/etcd/client/lease/EtcdLeaseClient.java
+++ b/src/main/java/com/ibm/etcd/client/lease/EtcdLeaseClient.java
@@ -70,7 +70,7 @@ import io.grpc.stub.StreamObserver;
 /**
  * 
  */
-public class EtcdLeaseClient implements LeaseClient, Closeable {
+public final class EtcdLeaseClient implements LeaseClient, Closeable {
     
     private static final Logger logger = LoggerFactory.getLogger(EtcdLeaseClient.class);
     
@@ -107,7 +107,7 @@ public class EtcdLeaseClient implements LeaseClient, Closeable {
                 .setID(leaseId).setTTL(ttlSecs).build(), false);
     }
     
-    class EtcdGrantRequest extends AbstractFluentRequest<FluentGrantRequest,
+    final class EtcdGrantRequest extends AbstractFluentRequest<FluentGrantRequest,
         LeaseGrantRequest,LeaseGrantResponse,LeaseGrantRequest.Builder> implements FluentGrantRequest {
 
         EtcdGrantRequest(long ttl) {
@@ -157,7 +157,7 @@ public class EtcdLeaseClient implements LeaseClient, Closeable {
                 .setKeys(includeKeys).build(), true);
     }
     
-    class KeepAliveFuture extends AbstractFuture<LeaseKeepAliveResponse> {
+    final class KeepAliveFuture extends AbstractFuture<LeaseKeepAliveResponse> {
         final long leaseId;
         public KeepAliveFuture(long leaseId) {
             this.leaseId = leaseId;
@@ -686,7 +686,7 @@ public class EtcdLeaseClient implements LeaseClient, Closeable {
         }
     }
     
-    class ProtectedLeaseRecord extends LeaseRecord {
+    final class ProtectedLeaseRecord extends LeaseRecord {
         public ProtectedLeaseRecord(long leaseId, int minExpirySecs, int intervalSecs,
                 StreamObserver<LeaseState> observer, Executor executor) {
             super(leaseId, minExpirySecs, intervalSecs, observer, executor);

--- a/src/main/java/com/ibm/etcd/client/watch/EtcdWatchClient.java
+++ b/src/main/java/com/ibm/etcd/client/watch/EtcdWatchClient.java
@@ -52,7 +52,7 @@ import io.grpc.stub.StreamObserver;
 /**
  * 
  */
-public class EtcdWatchClient implements Closeable {
+public final class EtcdWatchClient implements Closeable {
     
     private static final Logger logger = LoggerFactory.getLogger(EtcdWatchClient.class);
     
@@ -98,7 +98,7 @@ public class EtcdWatchClient implements Closeable {
     /**
      * Internal per-watch state
      */
-    class WatcherRecord {
+    final class WatcherRecord {
 
         private final StreamObserver<WatchUpdate> observer;
         private final WatchCreateRequest request;
@@ -293,7 +293,7 @@ public class EtcdWatchClient implements Closeable {
         return true;
     }
     
-    static class WatchHandle extends AbstractFuture<Boolean> implements Watch {
+    final static class WatchHandle extends AbstractFuture<Boolean> implements Watch {
         private final WeakReference<WatcherRecord> wrecRef;
         
         public WatchHandle(WatcherRecord wrec) {

--- a/src/main/java/com/ibm/etcd/client/watch/EtcdWatchIterator.java
+++ b/src/main/java/com/ibm/etcd/client/watch/EtcdWatchIterator.java
@@ -32,7 +32,7 @@ import io.grpc.stub.StreamObserver;
 /**
  * Converts async observer-based watch to sync iterator-based watch
  */
-class EtcdWatchIterator implements WatchIterator, StreamObserver<WatchUpdate> {
+final class EtcdWatchIterator implements WatchIterator, StreamObserver<WatchUpdate> {
     
     static class CompletedUpdate implements WatchUpdate {
         final RuntimeException error;

--- a/src/main/java/com/ibm/etcd/client/watch/EtcdWatchUpdate.java
+++ b/src/main/java/com/ibm/etcd/client/watch/EtcdWatchUpdate.java
@@ -28,7 +28,7 @@ import com.ibm.etcd.api.WatchResponse;
 /**
  * @see WatchUpdate
  */
-public class EtcdWatchUpdate implements WatchUpdate {
+final class EtcdWatchUpdate implements WatchUpdate {
 
     private final WatchResponse response;
 

--- a/src/main/proto/v3lock.proto
+++ b/src/main/proto/v3lock.proto
@@ -1,0 +1,68 @@
+syntax = "proto3";
+package v3lockpb;
+
+//import "gogoproto/gogo.proto";
+import "rpc.proto";
+
+// for grpc-gateway
+//import "google/api/annotations.proto";
+
+//option (gogoproto.marshaler_all) = true;
+//option (gogoproto.unmarshaler_all) = true;
+
+option java_package = "com.ibm.etcd.api";
+option java_multiple_files = true;
+
+// The lock service exposes client-side locking facilities as a gRPC interface.
+service Lock {
+  // Lock acquires a distributed shared lock on a given named lock.
+  // On success, it will return a unique key that exists so long as the
+  // lock is held by the caller. This key can be used in conjunction with
+  // transactions to safely ensure updates to etcd only occur while holding
+  // lock ownership. The lock is held until Unlock is called on the key or the
+  // lease associate with the owner expires.
+  rpc Lock(LockRequest) returns (LockResponse) {
+//      option (google.api.http) = {
+//        post: "/v3/lock/lock"
+//        body: "*"
+//    };
+  }
+
+  // Unlock takes a key returned by Lock and releases the hold on lock. The
+  // next Lock caller waiting for the lock will then be woken up and given
+  // ownership of the lock.
+  rpc Unlock(UnlockRequest) returns (UnlockResponse) {
+//      option (google.api.http) = {
+//        post: "/v3/lock/unlock"
+//        body: "*"
+//    };
+  }
+}
+
+message LockRequest {
+  // name is the identifier for the distributed shared lock to be acquired.
+  bytes name = 1;
+  // lease is the ID of the lease that will be attached to ownership of the
+  // lock. If the lease expires or is revoked and currently holds the lock,
+  // the lock is automatically released. Calls to Lock with the same lease will
+  // be treated as a single acquisition; locking twice with the same lease is a
+  // no-op.
+  int64 lease = 2;
+}
+
+message LockResponse {
+  etcdserverpb.ResponseHeader header = 1;
+  // key is a key that will exist on etcd for the duration that the Lock caller
+  // owns the lock. Users should not modify this key or the lock may exhibit
+  // undefined behavior.
+  bytes key = 2;
+}
+
+message UnlockRequest {
+  // key is the lock ownership key granted by Lock.
+  bytes key = 1;
+}
+
+message UnlockResponse {
+  etcdserverpb.ResponseHeader header = 1;
+}

--- a/src/test/java/com/ibm/etcd/client/EtcdTestSuite.java
+++ b/src/test/java/com/ibm/etcd/client/EtcdTestSuite.java
@@ -36,7 +36,7 @@ import com.ibm.etcd.client.utils.RangeCacheTest;
 
 @RunWith(Suite.class)
 @SuiteClasses({KvTest.class, WatchTest.class, LeaseTest.class,
-    PersistentLeaseKeyTest.class, RangeCacheTest.class})
+    LockTest.class, PersistentLeaseKeyTest.class, RangeCacheTest.class})
 public class EtcdTestSuite {
 
     static Process etcdProcess;

--- a/src/test/java/com/ibm/etcd/client/LockTest.java
+++ b/src/test/java/com/ibm/etcd/client/LockTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017, 2018 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ibm.etcd.client;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import com.google.protobuf.ByteString;
+import com.ibm.etcd.api.LeaseGrantResponse;
+import com.ibm.etcd.api.LockResponse;
+import com.ibm.etcd.client.kv.KvClient;
+import com.ibm.etcd.client.kv.LockClient;
+import com.ibm.etcd.client.lease.LeaseClient;
+import com.ibm.etcd.client.lease.PersistentLease;
+
+import io.grpc.Deadline;
+
+public class LockTest {
+
+    @Test
+    public void testLocks() throws Exception {
+        try(KvStoreClient client = EtcdClient.forEndpoint("localhost", 2379)
+                .withPlainText().build()) {
+            LockClient lc = client.getLockClient();
+            KvClient kvc = client.getKvClient();
+            LeaseClient lec = client.getLeaseClient();
+            
+            LockResponse lr = lc.lock(KeyUtils.bs("mylock"))
+                    .deadline(Deadline.after(500, TimeUnit.MILLISECONDS)).sync();
+            
+            ByteString lockKey = lr.getKey();
+            assertNotNull(lockKey);
+            assertTrue(kvc.txnIf().exists(lockKey).sync().getSucceeded());
+            
+            assertNotNull(lc.unlock(lockKey).sync());
+            assertFalse(kvc.txnIf().exists(lockKey).sync().getSucceeded());
+            
+            
+            LeaseGrantResponse lgr = lec.grant(3L).sync();
+            
+            lr = lc.lock(KeyUtils.bs("mylock2")).withLease(lgr.getID()).sync();
+            
+            lockKey = lr.getKey();
+            assertNotNull(lockKey);
+            assertTrue(kvc.txnIf().exists(lockKey).sync().getSucceeded());
+            
+            assertNotNull(lc.unlock(lockKey).sync());
+            assertFalse(kvc.txnIf().exists(lockKey).sync().getSucceeded());
+            
+            PersistentLease pl = lec.maintain().start();
+            
+            lr = lc.lock(KeyUtils.bs("mylock3")).withLease(pl).sync();
+            
+            lockKey = lr.getKey();
+            assertNotNull(lockKey);
+            assertTrue(kvc.txnIf().exists(lockKey).sync().getSucceeded());
+            
+            pl.close();
+            
+            Thread.sleep(500L); // don't currently have future for PL close unfortunately
+
+            assertFalse(kvc.txnIf().exists(lockKey).sync().getSucceeded());
+        }
+    }
+    
+}


### PR DESCRIPTION
V3 lock api support (see https://coreos.com/blog/etcd-3.2-announcement), integration with `PersistentLease`s and clients' session lease in particular.

Also change various internal classes to be `final`.