### PR TITLE
Handle http(s):// prefixed endpoints properly in all cases

### DIFF
--- a/src/test/java/com/ibm/etcd/client/ClientBuilderTest.java
+++ b/src/test/java/com/ibm/etcd/client/ClientBuilderTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017, 2018 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ibm.etcd.client;
+
+import static com.ibm.etcd.client.KeyUtils.bs;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+
+import org.junit.Test;
+
+import com.ibm.etcd.client.kv.KvClient;
+
+public class ClientBuilderTest {
+
+    @Test
+    public void testForEndpoint() throws Exception {
+        try (KvStoreClient client = EtcdClient.forEndpoint("localhost", 2379)
+                .withPlainText().build()) {
+            basicTest(client);
+        }
+    }
+
+    @Test
+    public void testForEndpointsSingle() throws Exception {
+        String[] endpoints = { "localhost:2379", "http://localhost:2379",
+                "https://localhost:2379", "dns:///localhost:2379" };
+
+        for (String endpoint : endpoints) {
+            try (KvStoreClient client = EtcdClient.forEndpoints(Collections.singletonList(endpoint))
+                    .withPlainText().build()) {
+                basicTest(client);
+            }
+        }
+    }
+
+    @Test
+    public void testForEndpointsMulti() throws Exception {
+        try (KvStoreClient client = EtcdClient.forEndpoints(
+                "localhost:2379,http://localhost:2379,https://localhost:2379,dns:///localhost:2379")
+                .withPlainText().build()) {
+            basicTest(client);
+        }
+    }
+
+    static void basicTest(KvStoreClient client) {
+        KvClient kvc = client.getKvClient();
+        kvc.put(bs("cbt"), bs("test")).sync();
+        assertEquals("test", kvc.delete(bs("cbt")).prevKv().sync()
+                .getPrevKvs(0).getValue().toStringUtf8());
+    }
+}

--- a/src/test/java/com/ibm/etcd/client/EtcdTestSuite.java
+++ b/src/test/java/com/ibm/etcd/client/EtcdTestSuite.java
@@ -35,7 +35,7 @@ import com.ibm.etcd.client.utils.PersistentLeaseKeyTest;
 import com.ibm.etcd.client.utils.RangeCacheTest;
 
 @RunWith(Suite.class)
-@SuiteClasses({KvTest.class, WatchTest.class, LeaseTest.class,
+@SuiteClasses({ClientBuilderTest.class, KvTest.class, WatchTest.class, LeaseTest.class,
     LockTest.class, PersistentLeaseKeyTest.class, RangeCacheTest.class})
 public class EtcdTestSuite {
 

--- a/src/test/java/com/ibm/etcd/client/KvTest.java
+++ b/src/test/java/com/ibm/etcd/client/KvTest.java
@@ -15,6 +15,7 @@
  */
 package com.ibm.etcd.client;
 
+import static com.ibm.etcd.client.KeyUtils.bs;
 import static org.junit.Assert.*;
 
 import java.util.UUID;
@@ -27,8 +28,6 @@ import org.junit.Test;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
-import com.ibm.etcd.client.EtcdClient;
-import com.ibm.etcd.client.KvStoreClient;
 import com.ibm.etcd.client.kv.KvClient;
 
 import io.grpc.Deadline;
@@ -186,10 +185,6 @@ public class KvTest {
                 client.getKvClient().delete(bs("deadlock-test/")).asPrefix().sync();
             }
         }
-    }
-
-    public static ByteString bs(String str) {
-        return ByteString.copyFromUtf8(str);
     }
 
     static String t(long start) {

--- a/src/test/java/com/ibm/etcd/client/WatchTest.java
+++ b/src/test/java/com/ibm/etcd/client/WatchTest.java
@@ -15,7 +15,7 @@
  */
 package com.ibm.etcd.client;
 
-import static com.ibm.etcd.client.KvTest.bs;
+import static com.ibm.etcd.client.KeyUtils.bs;
 import static com.ibm.etcd.client.KvTest.t;
 import static org.junit.Assert.*;
 

--- a/src/test/java/com/ibm/etcd/client/WatchTest.java
+++ b/src/test/java/com/ibm/etcd/client/WatchTest.java
@@ -163,7 +163,8 @@ public class WatchTest {
             proxy.start();
 
             // watch should be unaffected - next event seen should be the missed one
-            wu = (WatchUpdate)watchEvents.poll(5000L, TimeUnit.MILLISECONDS);
+            wu = (WatchUpdate) watchEvents.poll(6000L, TimeUnit.MILLISECONDS);
+            assertNotNull("Expected watch event not received after server reconnection", wu);
             assertEquals(bs("/watchtest/e"), wu.getEvents().get(0).getKv().getKey());
 
             watch.close();

--- a/src/test/java/com/ibm/etcd/client/utils/LeaderElectionTest.java
+++ b/src/test/java/com/ibm/etcd/client/utils/LeaderElectionTest.java
@@ -15,7 +15,7 @@
  */
 package com.ibm.etcd.client.utils;
 
-import static com.ibm.etcd.client.KvTest.bs;
+import static com.ibm.etcd.client.KeyUtils.bs;
 import static org.junit.Assert.*;
 
 import org.junit.Test;

--- a/src/test/java/com/ibm/etcd/client/utils/PersistentLeaseKeyTest.java
+++ b/src/test/java/com/ibm/etcd/client/utils/PersistentLeaseKeyTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.*;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.ibm.etcd.client.KvTest.bs;
+import static com.ibm.etcd.client.KeyUtils.bs;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import org.junit.AfterClass;

--- a/src/test/java/com/ibm/etcd/client/utils/RangeCacheTest.java
+++ b/src/test/java/com/ibm/etcd/client/utils/RangeCacheTest.java
@@ -18,7 +18,7 @@ package com.ibm.etcd.client.utils;
 import static com.ibm.etcd.client.KeyUtils.fromHexString;
 import static com.ibm.etcd.client.KeyUtils.plusOne;
 import static com.ibm.etcd.client.KeyUtils.toHexString;
-import static com.ibm.etcd.client.KvTest.bs;
+import static com.ibm.etcd.client.KeyUtils.bs;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;


### PR DESCRIPTION
Also
- Stop using deprecated method in grpc `NameResolver` API
- Add unit tests

Fixes #34 