### PR TITLE
Fix for endpoint format string regression

### DIFF
--- a/src/main/java/com/ibm/etcd/client/config/EtcdClusterConfig.java
+++ b/src/main/java/com/ibm/etcd/client/config/EtcdClusterConfig.java
@@ -103,11 +103,10 @@ public class EtcdClusterConfig {
         TlsMode ssl = tlsMode;
         if (ssl == TlsMode.AUTO || ssl == null) {
             String ep = endpointList.get(0);
-            if (ep.startsWith("http://")) ssl = TlsMode.PLAINTEXT;
-            else if (certificate != null || clientCertificate != null
-                    || ep.startsWith("https://")) {
-                ssl = TlsMode.TLS;
-            }
+            ssl = ep.startsWith("https://")
+                    || (!ep.startsWith("http://")
+                            && (certificate != null && clientCertificate != null))
+                    ? TlsMode.TLS : TlsMode.PLAINTEXT;
         }
         if (ssl == TlsMode.PLAINTEXT) {
             builder.withPlainText();

--- a/src/main/java/com/ibm/etcd/client/config/EtcdClusterConfig.java
+++ b/src/main/java/com/ibm/etcd/client/config/EtcdClusterConfig.java
@@ -105,7 +105,7 @@ public class EtcdClusterConfig {
             String ep = endpointList.get(0);
             ssl = ep.startsWith("https://")
                     || (!ep.startsWith("http://")
-                            && (certificate != null && clientCertificate != null))
+                            && (certificate != null || clientCertificate != null))
                     ? TlsMode.TLS : TlsMode.PLAINTEXT;
         }
         if (ssl == TlsMode.PLAINTEXT) {

--- a/src/test/java/com/ibm/etcd/client/JsonConfigTest.java
+++ b/src/test/java/com/ibm/etcd/client/JsonConfigTest.java
@@ -55,6 +55,12 @@ public class JsonConfigTest {
     }
 
     @Test
+    public void testBasicConfigNoScheme() throws Exception {
+        ByteSource json = makeJson("localhost:2379", null, null, null);
+        runBasicTests(EtcdClusterConfig.fromJson(json));
+    }
+
+    @Test
     public void testSslConfig() throws Exception {
         ByteSource json = makeJson("https://localhost:2360", EtcdTestSuite.serverCert, null, null);
         runBasicTests(EtcdClusterConfig.fromJson(json));


### PR DESCRIPTION
Unfortunately there was a regression in the last release when using `EtcdClusterConfig` with an endpoint string that doesn't include a `http://` or `https://` prefix, _and_ where TLS certs aren't provided. Per the prior behaviour this should imply plaintext connection but with the regression it attempts to use SSL.

Includes additional unit test to catch it.