### PR TITLE
fix: Avoid NullPointerException in certain conn error cases

### DIFF
--- a/src/main/java/com/ibm/etcd/client/EtcdClient.java
+++ b/src/main/java/com/ibm/etcd/client/EtcdClient.java
@@ -608,6 +608,9 @@ public class EtcdClient implements KvStoreClient {
     private long authFailRetryTime;
 
     protected static boolean reauthRequired(Throwable error) {
+        if (error == null) {
+            return false;
+        }
         Status status = Status.fromThrowable(error);
         Code code = status.getCode();
         return code == Code.UNAUTHENTICATED


### PR DESCRIPTION
#### Motivation

In rare cases it's possible that the status exception passed to the `EtcdClient#reauthRequired()` has `CANCELLED` gRPC code but no cause, which causes an NPE.

#### Modifications

Add null check to `EtcdClient#reauthRequired()`

#### Result

Avoid NPE