### PR TITLE
deps: Update dependencies

### DIFF
--- a/build-env/install-etcd.sh
+++ b/build-env/install-etcd.sh
@@ -3,7 +3,7 @@
 # Fail on any error
 set -e
 
-ETCD_VERSION=v3.3.22
+ETCD_VERSION=v3.4.20
 
 INSTALL_DIR="${1:-$HOME/etcd}"
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,16 +55,16 @@
    </distributionManagement>
 
    <properties>
-      <grpc-version>1.45.1</grpc-version>
+      <grpc-version>1.48.1</grpc-version>
       <!-- netty and protobuf versions kept in sync with grpc's deps -->
-      <netty-version>4.1.72.Final</netty-version>
-      <netty-tcnative-version>2.0.46.Final</netty-tcnative-version>
-      <protobuf-version>3.20.0</protobuf-version>
-      <gson-version>2.9.0</gson-version>
+      <netty-version>4.1.77.Final</netty-version>
+      <netty-tcnative-version>2.0.53.Final</netty-tcnative-version>
+      <protobuf-version>3.21.1</protobuf-version>
+      <gson-version>2.9.1</gson-version>
       <slf4j-version>1.7.36</slf4j-version>
       <junit-version>4.13.2</junit-version>
       <guava-version>31.1-jre</guava-version>
-      <annotations-version>9.0.62</annotations-version>
+      <annotations-version>9.0.65</annotations-version>
 
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
    </properties>


### PR DESCRIPTION
grpc, netty, netty-tcnative, protobuf, gson

Also update version of etcd used for tests from 3.3.22 to 3.4.20.