### PR TITLE
deps: Update grpc-java and netty dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,16 +55,16 @@
    </distributionManagement>
 
    <properties>
-      <grpc-version>1.48.1</grpc-version>
+      <grpc-version>1.50.0</grpc-version>
       <!-- netty and protobuf versions kept in sync with grpc's deps -->
-      <netty-version>4.1.77.Final</netty-version>
-      <netty-tcnative-version>2.0.53.Final</netty-tcnative-version>
+      <netty-version>4.1.79.Final</netty-version>
+      <netty-tcnative-version>2.0.54.Final</netty-tcnative-version>
       <protobuf-version>3.21.7</protobuf-version>
       <gson-version>2.9.1</gson-version>
       <slf4j-version>1.7.36</slf4j-version>
       <junit-version>4.13.2</junit-version>
       <guava-version>31.1-jre</guava-version>
-      <annotations-version>9.0.65</annotations-version>
+      <annotations-version>9.0.67</annotations-version>
 
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
    </properties>


### PR DESCRIPTION
grpc `1.50.0`, netty `4.1.79.Final`, netty-tcnative `2.0.54.Final`

netty/netty-tcnative are set to the versions corresponding to the grpc release