### PR TITLE
deps: Update to grpc 1.59.0 and netty-tcnative 2.0.62.Final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 jdk:
-- openjdk8
 - openjdk11
+- openjdk17
 
 env:
   global:

--- a/pom.xml
+++ b/pom.xml
@@ -55,10 +55,10 @@
    </distributionManagement>
 
    <properties>
-      <grpc-version>1.58.0</grpc-version>
+      <grpc-version>1.59.0</grpc-version>
       <!-- netty and protobuf versions kept in sync with grpc's deps -->
       <netty-version>4.1.100.Final</netty-version>
-      <netty-tcnative-version>2.0.56.Final</netty-tcnative-version>
+      <netty-tcnative-version>2.0.62.Final</netty-tcnative-version>
       <protobuf-version>3.24.4</protobuf-version>
       <gson-version>2.10.1</gson-version>
       <slf4j-version>1.7.36</slf4j-version>


### PR DESCRIPTION
Also update to build using openjdk17 and remove obsolete openjdk8 build.