### PR TITLE
Integrate dependabot to automate updating dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,14 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "maven" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+    rebase-strategy: "auto"

--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.3.1</version>
+            <version>3.6.3</version>
             <configuration>
                <source>8</source>
                <breakiterator>true</breakiterator>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
       <!-- netty versions kept in sync with grpc's deps -->
       <netty-version>4.1.107.Final</netty-version>
       <netty-tcnative-version>2.0.62.Final</netty-tcnative-version>
-      <protobuf-version>3.25.0</protobuf-version>
+      <protobuf-version>3.25.3</protobuf-version>
       <gson-version>2.10.1</gson-version>
       <slf4j-version>1.7.36</slf4j-version>
       <junit-version>4.13.2</junit-version>

--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>2.22.2</version>
+            <version>3.2.5</version>
             <configuration>
                <includes>
                   <include>**/*TestSuite.java</include>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
    <properties>
       <grpc-version>1.59.0</grpc-version>
       <!-- netty versions kept in sync with grpc's deps -->
-      <netty-version>4.1.97.Final</netty-version>
+      <netty-version>4.1.107.Final</netty-version>
       <netty-tcnative-version>2.0.62.Final</netty-tcnative-version>
       <protobuf-version>3.25.0</protobuf-version>
       <gson-version>2.10.1</gson-version>

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
          <extension>
             <groupId>kr.motd.maven</groupId>
             <artifactId>os-maven-plugin</artifactId>
-            <version>1.6.2</version>
+            <version>1.7.1</version>
          </extension>
       </extensions>
       <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
          </plugin>
          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.8.1</version>
+            <version>3.12.1</version>
             <configuration>
                <source>1.8</source>
                <target>1.8</target>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
       <gson-version>2.10.1</gson-version>
       <slf4j-version>1.7.36</slf4j-version>
       <junit-version>4.13.2</junit-version>
-      <guava-version>32.1.3-jre</guava-version>
+      <guava-version>33.0.0-jre</guava-version>
       <annotations-version>9.0.82</annotations-version>
 
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
       <grpc-version>1.59.0</grpc-version>
       <!-- netty versions kept in sync with grpc's deps -->
       <netty-version>4.1.97.Final</netty-version>
-      <netty-tcnative-version>2.0.61.Final</netty-tcnative-version>
+      <netty-tcnative-version>2.0.62.Final</netty-tcnative-version>
       <protobuf-version>3.25.0</protobuf-version>
       <gson-version>2.10.1</gson-version>
       <slf4j-version>1.7.36</slf4j-version>


### PR DESCRIPTION
### Summary

- Add dependabot configuration to automate workflow of updating dependencies
- Including minor updates for dependencies generated by the bot in my forked repo

PRs which are generated by bot are https://github.com/akirafujiu/etcd-java/pulls?q=is%3Apr+is%3Aclosed+deps

It is actually pretty same PR as #81 

### Configuration

In order to use this dependabot, you need to modify configuration of this repository

Go to `Setting` tab ->  `Code security and analysis`  in `Security` section ->  `Dependabot version updates`  

![スクリーンショット 2024-02-19 18 08 32](https://github.com/IBM/etcd-java/assets/9509481/f452ca15-4759-4716-ac13-d810004ea23f)



