### PR TITLE
add release.yaml to automate release notes generation

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,13 @@
+# .github/release.yml
+
+changelog:
+  categories:
+    - title: 🏕 Features
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - dependencies
+    - title: 👒 Dependencies
+      labels:
+        - dependencies


### PR DESCRIPTION
### Summary

Here is another automation flow to create release note based on https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes. It should consume labels on issues & prs, then group them into sections in a release note.

Here is a result which I tested on my forked repo: https://github.com/akirafujiu/etcd-java/releases/tag/0.0.1-test