### PR TITLE
Fix CVE-2024-7254

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
       <!-- netty versions kept in sync with grpc's deps -->
       <netty-version>4.1.107.Final</netty-version>
       <netty-tcnative-version>2.0.62.Final</netty-tcnative-version>
-      <protobuf-version>3.25.3</protobuf-version>
+      <protobuf-version>3.25.5</protobuf-version>
       <gson-version>2.10.1</gson-version>
       <slf4j-version>1.7.36</slf4j-version>
       <junit-version>4.13.2</junit-version>


### PR DESCRIPTION
chore: Fix CVE-2024-7254:
Overview
com.google.protobuf:protobuf-java is a Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data.

Affected versions of this package are vulnerable to Stack-based Buffer Overflow via the parsing of nested groups or series of SGROUP tags as unknown fields with DiscardUnknownFieldsParser or Java Protobuf Lite parser, or against Protobuf map fields. An attacker can cause infinite recursion by sending malicious Protocol Buffer data.